### PR TITLE
Rat lab 2 mvvm cyfluv

### DIFF
--- a/LAB10_AttaxxPlus/AttaxxPlus/AttaxxPlus.csproj
+++ b/LAB10_AttaxxPlus/AttaxxPlus/AttaxxPlus.csproj
@@ -121,6 +121,7 @@
     </Compile>
     <Compile Include="Boosters\BoosterBase.cs" />
     <Compile Include="Boosters\DummyBooster.cs" />
+    <Compile Include="Boosters\EmptyRowColBooster.cs" />
     <Compile Include="Boosters\IBooster.cs" />
     <Compile Include="Boosters\SurrenderBooster.cs" />
     <Compile Include="MainPage.xaml.cs">

--- a/LAB10_AttaxxPlus/AttaxxPlus/Boosters/DummyBooster.cs
+++ b/LAB10_AttaxxPlus/AttaxxPlus/Boosters/DummyBooster.cs
@@ -36,6 +36,7 @@ namespace AttaxxPlus.Boosters
             usableCounter[0] = 0;
             usableCounter[1] = 2;
             usableCounter[2] = 2;
+            CurrentPlayerChanged();
         }
 
         public override bool TryExecute(Field selectedField, Field currentField)

--- a/LAB10_AttaxxPlus/AttaxxPlus/Boosters/DummyBooster.cs
+++ b/LAB10_AttaxxPlus/AttaxxPlus/Boosters/DummyBooster.cs
@@ -36,7 +36,7 @@ namespace AttaxxPlus.Boosters
             usableCounter[0] = 0;
             usableCounter[1] = 2;
             usableCounter[2] = 2;
-            CurrentPlayerChanged();
+            Notify(nameof(this.Title));
         }
 
         public override bool TryExecute(Field selectedField, Field currentField)

--- a/LAB10_AttaxxPlus/AttaxxPlus/Boosters/DummyBooster.cs
+++ b/LAB10_AttaxxPlus/AttaxxPlus/Boosters/DummyBooster.cs
@@ -45,7 +45,7 @@ namespace AttaxxPlus.Boosters
                 Notify(nameof(Title));
                 return true;
             }
-            return true;
+            return false;
         }
     }
 }

--- a/LAB10_AttaxxPlus/AttaxxPlus/Boosters/DummyBooster.cs
+++ b/LAB10_AttaxxPlus/AttaxxPlus/Boosters/DummyBooster.cs
@@ -10,10 +10,10 @@ namespace AttaxxPlus.Boosters
     public class DummyBooster : BoosterBase
     {
         // How many times can the user activate this booster
-        private int usableCounter = 2;
+        private readonly int[] usableCounter = { 0, 2, 2};
 
         // EVIP: overriding abstract property in base class.
-        public override string Title { get => $"Dummy ({usableCounter})"; }
+        public override string Title { get => $"Dummy ({usableCounter[GameViewModel.CurrentPlayer]})"; }
 
         public DummyBooster()
             : base()
@@ -33,15 +33,17 @@ namespace AttaxxPlus.Boosters
 
         public override void InitializeGame()
         {
-            usableCounter = 2;
+            usableCounter[0] = 0;
+            usableCounter[1] = 2;
+            usableCounter[2] = 2;
         }
 
         public override bool TryExecute(Field selectedField, Field currentField)
         {
             // Note: if you need a player-dependent counter, use this.GameViewModel.CurrentPlayer.
-            if (usableCounter > 0)
+            if (usableCounter[GameViewModel.CurrentPlayer] > 0)
             {
-                usableCounter--;
+                usableCounter[GameViewModel.CurrentPlayer]--;
                 Notify(nameof(Title));
                 return true;
             }

--- a/LAB10_AttaxxPlus/AttaxxPlus/Boosters/EmptyRowColBooster.cs
+++ b/LAB10_AttaxxPlus/AttaxxPlus/Boosters/EmptyRowColBooster.cs
@@ -1,0 +1,62 @@
+﻿using AttaxxPlus.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AttaxxPlus.Boosters
+{
+    /// <summary>
+    /// Booster deleting all elements in the selected row and column.
+    /// </summary>
+    public class EmptyRowColBooster : BoosterBase
+    {
+        // How many times can the user activate this booster
+        private readonly int[] usableCounter = { 0, 1, 1 };
+
+        // EVIP: overriding abstract property in base class.
+        public override string Title { get => $"CrossClean ({usableCounter[GameViewModel.CurrentPlayer]})"; }
+
+        public EmptyRowColBooster() : base()
+        {
+        }
+
+        protected override void CurrentPlayerChanged()
+        {
+            base.CurrentPlayerChanged();
+            Notify(nameof(this.Title));
+        }
+
+        public override void InitializeGame()
+        {
+            usableCounter[0] = 0;
+            usableCounter[1] = 1;
+            usableCounter[2] = 1;
+            Notify(nameof(this.Title));
+        }
+
+        public override bool TryExecute(Field selectedField, Field currentField)
+        {
+            if (usableCounter[GameViewModel.CurrentPlayer] > 0)
+            {
+                usableCounter[GameViewModel.CurrentPlayer]--;
+                ClearRowCol();
+                Notify(nameof(Title));
+                return true;
+            }
+            return false;
+        }
+
+        private void ClearRowCol()
+        {
+            foreach (var item in GameViewModel.Model.Fields)
+            {
+                if ((item.Row == GameViewModel.SelectedField.Model.Row || item.Column == GameViewModel.SelectedField.Model.Column) && item.Owner != 0)
+                {
+                    item.Owner = 0;                                  
+                }
+            }
+        }
+    }
+}

--- a/LAB10_AttaxxPlus/AttaxxPlus/Boosters/SurrenderBooster.cs
+++ b/LAB10_AttaxxPlus/AttaxxPlus/Boosters/SurrenderBooster.cs
@@ -13,11 +13,28 @@ namespace AttaxxPlus.Boosters
 
         public SurrenderBooster() : base()
         {
+            LoadImage(new Uri(@"ms-appx:///Boosters/SurrenderBooster.png"));
+        }
+
+        protected override void CurrentPlayerChanged()
+        {
+            base.CurrentPlayerChanged();
+            Notify(nameof(this.Title));
         }
 
         public override bool TryExecute(Field selectedField, Field currentField)
         {
-            return false;
+            foreach (var item in GameViewModel.Model.Fields)
+            {
+                if (item.Owner == 0)
+                {
+                    if (GameViewModel.CurrentPlayer == 1)
+                        item.Owner = 2;
+                    else if (GameViewModel.CurrentPlayer == 2)
+                        item.Owner = 1;
+                }
+            }       
+            return true;
         }
     }
 }

--- a/LAB10_AttaxxPlus/AttaxxPlus/Model/GameBase.cs
+++ b/LAB10_AttaxxPlus/AttaxxPlus/Model/GameBase.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace AttaxxPlus.Model
 {
@@ -102,7 +104,90 @@ namespace AttaxxPlus.Model
                     ? playerWithMaxFields : 0;
                 return true;
             }
+
+
+            //Check if player 2 or player 1 is surrounded
+            List<(int, int)> positions1 = FindPos(1);            
+            bool allSorrounded1 = true;
+            foreach (var item in positions1)
+            {
+                if (!CheckSurround(item.Item1, item.Item2))
+                    allSorrounded1 = false;
+            }
+            if (allSorrounded1)
+            {
+                Winner = 2;
+                return true;
+            }
+
+            List<(int, int)> positions2 = FindPos(2);
+            bool allSorrounded2 = true;
+            foreach (var item in positions2)
+            {
+                if (!CheckSurround(item.Item1, item.Item2))
+                    allSorrounded2 = false;              
+            }
+            if (allSorrounded2)
+            {
+                Winner = 1;
+                return true;
+            }
+
             return false;
+        }        
+
+        private List<(int row, int col)>  FindPos(int player)
+        {
+            List<(int, int)> pos = new List<(int, int)>();
+            foreach (var item in Fields)
+            {
+                if (item.Owner == player)
+                {
+                    pos.Add((item.Row, item.Column));
+                }
+            }
+            return pos;
         }
+
+        private bool CheckSurround(int row, int col)
+        {
+            List<Field> surroundings = CaluclateSurroundings(row, col);
+
+            foreach (var item in surroundings)
+            {
+                if (item.Owner == 0)
+                {
+                    return false;
+                }
+            }
+            return true;
+
+        }
+
+        private List<Field> CaluclateSurroundings(int row, int col)
+        {
+            List<Field> surroundings = new List<Field>();
+
+            int deltaRow;
+            int deltaCol;
+            foreach (var item in Fields)
+            {
+                deltaRow = Math.Abs(item.Row - row);
+                deltaCol = Math.Abs(item.Column - col);
+
+                if (deltaRow == 0 && deltaCol == 0)
+                    continue;
+
+                if ((deltaRow <= 2 && deltaCol == 0) ||
+                    (deltaRow == 0 && deltaCol <= 2) ||
+                    (deltaRow == 1 && deltaCol == 1))
+                {
+                    surroundings.Add(item);
+                }
+            }
+
+            return surroundings;
+        }
+
     }
 }

--- a/LAB10_AttaxxPlus/AttaxxPlus/Model/Operations/CloneMoveOperation.cs
+++ b/LAB10_AttaxxPlus/AttaxxPlus/Model/Operations/CloneMoveOperation.cs
@@ -15,10 +15,9 @@ namespace AttaxxPlus.Model.Operations
 
             // Note: selectedField is always the players own field...
             // EVIP: IsEmpty() is more descriptive than "Owner == 0"
-            if (Math.Abs(selectedField.Row - currentField.Row)
-                + Math.Abs(selectedField.Column - currentField.Column) == 1
-                && !selectedField.IsEmpty()
-                && currentField.IsEmpty())
+            int rowDist = Math.Abs(selectedField.Row - currentField.Row);
+            int colDist = Math.Abs(selectedField.Column - currentField.Column);
+            if ((rowDist + colDist == 1 || (rowDist == 1 && colDist == 1)) && !selectedField.IsEmpty() && currentField.IsEmpty())
             {
                 currentField.Owner = selectedField.Owner;
                 // EVIP: using more general helper method implemented by base class

--- a/LAB10_AttaxxPlus/AttaxxPlus/View/IsSelected2BrushConverter.cs
+++ b/LAB10_AttaxxPlus/AttaxxPlus/View/IsSelected2BrushConverter.cs
@@ -9,11 +9,12 @@ namespace AttaxxPlus.View
     {
         // EVIP: reusing brushes, named constants
         readonly private static SolidColorBrush yellow = new SolidColorBrush(Colors.Yellow);
+        readonly private static SolidColorBrush brown = new SolidColorBrush(Colors.Brown);
         readonly private static SolidColorBrush gray = new SolidColorBrush(Colors.Gray);
 
         public object Convert(object value, Type targetType, object parameter, string language)
         {
-            return ((bool)value) ? yellow : gray;
+            return ((bool)value) ? brown : gray;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/LAB10_AttaxxPlus/AttaxxPlus/ViewModel/BoosterListViewModel.cs
+++ b/LAB10_AttaxxPlus/AttaxxPlus/ViewModel/BoosterListViewModel.cs
@@ -24,6 +24,7 @@ namespace AttaxxPlus.ViewModel
                 // EVIP: using reflection to instantiate objects
                 IBooster booster = Activator.CreateInstance(boosterType.AsType()) as IBooster;
                 booster.GameViewModel = gameViewModel;
+                Boosters.Add(booster);
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Erről a repositoryról készülnek a hallgatói személyes másolatok a classro
 A repository private, a tárgy oktatóin kívül más nem láthatja.
 Az egyértelmű azonosíthatóság érdekében kérünk, add meg az alábbiakat:
 
-## NÉV: 
-## Neptun-kód: 
-## Kurzus: 
+## NÉV: Sághy Dániel
+## Neptun-kód: CYFLUV
+## Kurzus: L1
 
 # Hasznos linkek 
 


### PR DESCRIPTION
**Megjegyzések az elkészült megoldáshoz**



**Ellenőrzési lista**
- A pull request címe utal a tartalomra. Pl. LAB05
- A pull requestben csak azok a változások szerepelnek, amiket a megoldás során te hajtottál végre.
- A forráskódban nincsennek kikommentezett kódrészletek, egymás után több üres sor.
- Reviewernek megadtad a Neptun szerinti kurzusod laborvezetőjét, és csak 1 reviewert adtál meg.
- Ha a feladatban unit tesztek bezöldítése vagy UI fejlesztés volt a feladat, a test explorerről vagy az elkészült felhasználói felületről készített screenshot szerepel a pull request leírásában (itt, és nem egy becommitolt fájlban a forráskód mellett).
(Ezt az ellenőrzési listát nyugodtan benne hagyhatod a pull request szövegében.)
- Ha a feladatban felhasználói felületet kellett készíteni, arról rakj be ide egy screenshotot.


2. feladat:  
<local:OwnerIndex2BrushConverter x:Key="OwnerIndex2BrushConverter_modified"/>
Converter={StaticResource OwnerIndex2BrushConverter}
WinRT information: Cannot find a resource with the given key: OwnerIndex2BrushConverter.

3. feladat:
Ha csak a current.Isselected=true lenne, akkor a GameViewModelben a SelectedField nem frissülne, így nem tudnánk új mezőket kiválasztani, tehát nem tudnánk tovább lépni

4. szorgalmi:
![image](https://user-images.githubusercontent.com/38724183/110788493-fc8c5200-826e-11eb-88a7-f507f739f360.png)
![image](https://user-images.githubusercontent.com/38724183/110788511-03b36000-826f-11eb-87b1-779d751c8df8.png)
